### PR TITLE
Add Calendar tab and bottom tab bar navigation

### DIFF
--- a/BirthdayReminder.xcodeproj/project.pbxproj
+++ b/BirthdayReminder.xcodeproj/project.pbxproj
@@ -117,11 +117,6 @@
 			path = Shared;
 			sourceTree = "<group>";
 		};
-		AA22BB33CC44DD55EE66FF77 /* BirthdayReminderTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = BirthdayReminderTests;
-			sourceTree = "<group>";
-		};
 		204C55A12F4B367B00B536BB /* BirthdayReminder */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
@@ -137,6 +132,11 @@
 				204C55D62F4B40B300B536BB /* Exceptions for "BirthdayShareExtension" folder in "BirthdayShareExtension" target */,
 			);
 			path = BirthdayShareExtension;
+			sourceTree = "<group>";
+		};
+		AA22BB33CC44DD55EE66FF77 /* BirthdayReminderTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = BirthdayReminderTests;
 			sourceTree = "<group>";
 		};
 		CC33DD44EE55FF66AA778899 /* BirthdayWidget */ = {
@@ -207,29 +207,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		AA66BB77CC88DD99EEAAFFBB /* BirthdayReminderTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = AA99BBAACC11DD22EE33FF44 /* Build configuration list for PBXNativeTarget "BirthdayReminderTests" */;
-			buildPhases = (
-				AA55BB66CC77DD88EE99FFAA /* Sources */,
-				AA33BB44CC55DD66EE77FF88 /* Frameworks */,
-				AA44BB55CC66DD77EE88FF99 /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				AABBBCCC33DD44EE55FF6677 /* PBXTargetDependency */,
-			);
-			fileSystemSynchronizedGroups = (
-				AA22BB33CC44DD55EE66FF77 /* BirthdayReminderTests */,
-			);
-			name = BirthdayReminderTests;
-			packageProductDependencies = (
-			);
-			productName = BirthdayReminderTests;
-			productReference = AA11BB22CC33DD44EE55FF66 /* BirthdayReminderTests.xctest */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		204C559E2F4B367B00B536BB /* BirthdayReminder */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 204C55AA2F4B367C00B536BB /* Build configuration list for PBXNativeTarget "BirthdayReminder" */;
@@ -279,6 +256,29 @@
 			productName = BirthdayShareExtension;
 			productReference = 204C55CB2F4B40B300B536BB /* BirthdayShareExtension.appex */;
 			productType = "com.apple.product-type.app-extension";
+		};
+		AA66BB77CC88DD99EEAAFFBB /* BirthdayReminderTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AA99BBAACC11DD22EE33FF44 /* Build configuration list for PBXNativeTarget "BirthdayReminderTests" */;
+			buildPhases = (
+				AA55BB66CC77DD88EE99FFAA /* Sources */,
+				AA33BB44CC55DD66EE77FF88 /* Frameworks */,
+				AA44BB55CC66DD77EE88FF99 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AABBBCCC33DD44EE55FF6677 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				AA22BB33CC44DD55EE66FF77 /* BirthdayReminderTests */,
+			);
+			name = BirthdayReminderTests;
+			packageProductDependencies = (
+			);
+			productName = BirthdayReminderTests;
+			productReference = AA11BB22CC33DD44EE55FF66 /* BirthdayReminderTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		CC11DD22EE33FF44AA556677 /* BirthdayWidget */ = {
 			isa = PBXNativeTarget;

--- a/BirthdayReminder/ContentView.swift
+++ b/BirthdayReminder/ContentView.swift
@@ -2,7 +2,14 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        BirthdayListView()
+        TabView {
+            BirthdayListView()
+                .tabItem { Label("Home", systemImage: "house.fill") }
+            CalendarView()
+                .tabItem { Label("Calendar", systemImage: "calendar") }
+            SettingsView()
+                .tabItem { Label("Settings", systemImage: "gearshape") }
+        }
     }
 }
 

--- a/BirthdayReminder/Views/BirthdayListView.swift
+++ b/BirthdayReminder/Views/BirthdayListView.swift
@@ -9,7 +9,6 @@ struct BirthdayListView: View {
     @AppStorage("autoRefreshContacts") private var autoRefreshContacts = true
 
     @State private var showAddPerson = false
-    @State private var showSettings = false
     @State private var isImportingContacts = false
     @State private var importError: String?
     @State private var showImportError = false
@@ -199,17 +198,9 @@ struct BirthdayListView: View {
                     }
                     .disabled(isImportingContacts)
                 }
-                ToolbarItem(placement: .topBarLeading) {
-                    Button { showSettings = true } label: {
-                        Image(systemName: "gearshape")
-                    }
-                }
             }
             .sheet(isPresented: $showAddPerson) {
                 AddPersonView()
-            }
-            .sheet(isPresented: $showSettings) {
-                SettingsView()
             }
             .alert("Import Failed", isPresented: $showImportError) {
                 Button("OK", role: .cancel) {}

--- a/BirthdayReminder/Views/CalendarView.swift
+++ b/BirthdayReminder/Views/CalendarView.swift
@@ -1,0 +1,242 @@
+import SwiftUI
+import SwiftData
+
+// MARK: - Logic
+
+enum CalendarViewLogic {
+
+    /// Returns 42 slots (6 rows × 7 cols). nil = empty padding cell.
+    static func gridDates(for month: Date, calendar: Calendar = .current) -> [Date?] {
+        var comps = calendar.dateComponents([.year, .month], from: month)
+        comps.day = 1
+        guard let firstDay = calendar.date(from: comps),
+              let range = calendar.range(of: .day, in: .month, for: firstDay) else {
+            return Array(repeating: nil, count: 42)
+        }
+
+        let firstWeekday = calendar.component(.weekday, from: firstDay)
+        let offset = (firstWeekday - calendar.firstWeekday + 7) % 7
+
+        var slots: [Date?] = Array(repeating: nil, count: offset)
+        for day in range {
+            var dc = comps
+            dc.day = day
+            slots.append(calendar.date(from: dc))
+        }
+        while slots.count < 42 {
+            slots.append(nil)
+        }
+        return slots
+    }
+
+    static func nextMonth(_ date: Date, calendar: Calendar = .current) -> Date {
+        calendar.date(byAdding: .month, value: 1, to: date) ?? date
+    }
+
+    static func previousMonth(_ date: Date, calendar: Calendar = .current) -> Date {
+        calendar.date(byAdding: .month, value: -1, to: date) ?? date
+    }
+
+    /// Returns non-excluded people with a birthday on the given month/day.
+    static func birthdayPeople(inMonth month: Int, onDay day: Int, from people: [Person]) -> [Person] {
+        people.filter { p in
+            !p.isExcluded
+            && p.birthdayMonth == month
+            && p.birthdayDay == day
+        }
+    }
+}
+
+// MARK: - View
+
+struct CalendarView: View {
+    @State private var displayedMonth: Date = {
+        let cal = Calendar.current
+        let comps = cal.dateComponents([.year, .month], from: Date())
+        return cal.date(from: comps) ?? Date()
+    }()
+    @State private var selectedDay: Int? = Calendar.current.component(.day, from: Date())
+
+    @Query private var allPeople: [Person]
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 0), count: 7)
+    private let dayLabels = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                monthHeader
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+
+                dayOfWeekRow
+                    .padding(.horizontal, 4)
+                    .padding(.top, 4)
+
+                LazyVGrid(columns: columns, spacing: 0) {
+                    ForEach(Array(CalendarViewLogic.gridDates(for: displayedMonth).enumerated()), id: \.offset) { _, slot in
+                        if let date = slot {
+                            let day = Calendar.current.component(.day, from: date)
+                            let month = Calendar.current.component(.month, from: date)
+                            let hasBirthdays = !CalendarViewLogic.birthdayPeople(
+                                inMonth: month, onDay: day, from: allPeople
+                            ).isEmpty
+                            DayCell(
+                                day: day,
+                                isToday: Calendar.current.isDateInToday(date),
+                                isSelected: selectedDay == day,
+                                hasBirthdays: hasBirthdays
+                            )
+                            .onTapGesture { selectedDay = day }
+                        } else {
+                            Color.clear
+                                .frame(height: 44)
+                        }
+                    }
+                }
+                .padding(.horizontal, 4)
+
+                Divider()
+                    .padding(.top, 8)
+
+                birthdayList
+            }
+            .navigationTitle("Calendar")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    // MARK: - Subviews
+
+    private var monthHeader: some View {
+        HStack {
+            Button {
+                displayedMonth = CalendarViewLogic.previousMonth(displayedMonth)
+                selectedDay = nil
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.title3.weight(.semibold))
+                    .frame(width: 44, height: 44)
+            }
+
+            Spacer()
+
+            Text(monthTitle)
+                .font(.headline)
+
+            Spacer()
+
+            Button {
+                displayedMonth = CalendarViewLogic.nextMonth(displayedMonth)
+                selectedDay = nil
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.title3.weight(.semibold))
+                    .frame(width: 44, height: 44)
+            }
+        }
+    }
+
+    private var dayOfWeekRow: some View {
+        HStack(spacing: 0) {
+            ForEach(dayLabels, id: \.self) { label in
+                Text(label)
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var birthdayList: some View {
+        let month = Calendar.current.component(.month, from: displayedMonth)
+        let people: [Person] = selectedDay.map {
+            CalendarViewLogic.birthdayPeople(inMonth: month, onDay: $0, from: allPeople)
+        } ?? []
+
+        let headerText: String = {
+            guard let day = selectedDay else { return "No birthdays" }
+            var comps = DateComponents()
+            comps.month = month
+            comps.day = day
+            comps.year = 2000
+            if let d = Calendar.current.date(from: comps) {
+                let fmt = DateFormatter()
+                fmt.dateFormat = "MMM d"
+                return fmt.string(from: d)
+            }
+            return "\(month)/\(day)"
+        }()
+
+        List {
+            Section(header: Text(headerText)) {
+                if people.isEmpty {
+                    Text(selectedDay == nil ? "Select a day to see birthdays." : "No birthdays on this day.")
+                        .foregroundStyle(.secondary)
+                        .font(.subheadline)
+                } else {
+                    ForEach(people) { person in
+                        NavigationLink(destination: PersonDetailView(person: person, style: tileStyle(for: person))) {
+                            PersonTileView(person: person, style: tileStyle(for: person))
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Helpers
+
+    private var monthTitle: String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "MMMM yyyy"
+        return fmt.string(from: displayedMonth)
+    }
+
+    private func tileStyle(for person: Person) -> TileStyle {
+        if person.isBirthdayToday { return .today }
+        if person.isMissedYesterday { return .missed }
+        if (person.daysSinceBirthday ?? -1) > 0 { return .past }
+        return .upcoming
+    }
+}
+
+// MARK: - DayCell
+
+private struct DayCell: View {
+    let day: Int
+    let isToday: Bool
+    let isSelected: Bool
+    let hasBirthdays: Bool
+
+    var body: some View {
+        VStack(spacing: 2) {
+            ZStack {
+                Circle()
+                    .fill(circleColor)
+                    .frame(width: 32, height: 32)
+                Text("\(day)")
+                    .font(.callout)
+                    .foregroundStyle(textColor)
+            }
+            Circle()
+                .fill(hasBirthdays ? Color.orange : Color.clear)
+                .frame(width: 5, height: 5)
+        }
+        .frame(height: 44)
+        .frame(maxWidth: .infinity)
+    }
+
+    private var circleColor: Color {
+        if isToday { return .blue }
+        if isSelected { return Color(.systemGray5) }
+        return .clear
+    }
+
+    private var textColor: Color {
+        if isToday { return .white }
+        return .primary
+    }
+}

--- a/BirthdayReminder/Views/SettingsView.swift
+++ b/BirthdayReminder/Views/SettingsView.swift
@@ -9,7 +9,6 @@ struct SettingsView: View {
     @AppStorage(Keys.autoRefreshContacts) private var autoRefreshContacts = true
 
     @Environment(\.modelContext) private var modelContext
-    @Environment(\.dismiss)      private var dismiss
 
     @Query(filter: #Predicate<Person> { $0.isExcluded },
            sort: \Person.familyName)
@@ -81,12 +80,6 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                        .fontWeight(.semibold)
-                }
-            }
         }
     }
 

--- a/BirthdayReminderTests/CalendarViewTests.swift
+++ b/BirthdayReminderTests/CalendarViewTests.swift
@@ -1,0 +1,192 @@
+import XCTest
+import SwiftData
+@testable import BirthdayReminder
+
+final class CalendarViewTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let schema = Schema([Person.self, WishlistItem.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    private func makePerson(month: Int? = nil, day: Int? = nil, isExcluded: Bool = false) -> Person {
+        let p = Person()
+        p.birthdayMonth = month
+        p.birthdayDay = day
+        p.isExcluded = isExcluded
+        context.insert(p)
+        return p
+    }
+
+    private func firstOfMonth(year: Int, month: Int, calendar: Calendar = .current) -> Date {
+        var comps = DateComponents()
+        comps.year = year
+        comps.month = month
+        comps.day = 1
+        return calendar.date(from: comps)!
+    }
+
+    // MARK: - gridDates
+
+    func testGridDates_alwaysReturns42() {
+        // Test several different months to confirm count is always 42
+        let months = [
+            firstOfMonth(year: 2026, month: 1),
+            firstOfMonth(year: 2026, month: 2),
+            firstOfMonth(year: 2024, month: 2),
+            firstOfMonth(year: 2025, month: 7),
+            firstOfMonth(year: 2025, month: 12),
+        ]
+        for month in months {
+            XCTAssertEqual(CalendarViewLogic.gridDates(for: month).count, 42, "Expected 42 for \(month)")
+        }
+    }
+
+    func testGridDates_leadingNilsMatchWeekdayOffset() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1 // Sunday = 1
+
+        // Feb 1, 2026 falls on a Sunday (weekday 1), so offset should be 0
+        let feb2026 = firstOfMonth(year: 2026, month: 2, calendar: calendar)
+        let slots = CalendarViewLogic.gridDates(for: feb2026, calendar: calendar)
+        let leadingNils = slots.prefix(while: { $0 == nil }).count
+        let firstWeekday = calendar.component(.weekday, from: feb2026)
+        let expectedOffset = (firstWeekday - calendar.firstWeekday + 7) % 7
+        XCTAssertEqual(leadingNils, expectedOffset)
+
+        // March 1, 2026 falls on a Sunday too — offset 0
+        let mar2026 = firstOfMonth(year: 2026, month: 3, calendar: calendar)
+        let marSlots = CalendarViewLogic.gridDates(for: mar2026, calendar: calendar)
+        let marLeadingNils = marSlots.prefix(while: { $0 == nil }).count
+        let marFirstWeekday = calendar.component(.weekday, from: mar2026)
+        let marExpectedOffset = (marFirstWeekday - calendar.firstWeekday + 7) % 7
+        XCTAssertEqual(marLeadingNils, marExpectedOffset)
+    }
+
+    func testGridDates_allDaysOfMonthPresent() {
+        let calendar = Calendar.current
+        let month = firstOfMonth(year: 2025, month: 6) // June: 30 days
+        let slots = CalendarViewLogic.gridDates(for: month, calendar: calendar)
+        let nonNilDays = slots.compactMap { $0 }.map { calendar.component(.day, from: $0) }
+        XCTAssertEqual(nonNilDays.count, 30)
+        for day in 1...30 {
+            XCTAssertTrue(nonNilDays.contains(day), "Day \(day) missing from June 2025")
+        }
+    }
+
+    func testGridDates_february2026_28days() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1
+
+        let feb2026 = firstOfMonth(year: 2026, month: 2, calendar: calendar)
+        let slots = CalendarViewLogic.gridDates(for: feb2026, calendar: calendar)
+
+        // Feb 2026 has 28 days
+        let nonNilSlots = slots.compactMap { $0 }
+        XCTAssertEqual(nonNilSlots.count, 28)
+
+        // Feb 1, 2026 is a Sunday (weekday 1 in a Sunday-first calendar) → offset 0
+        let firstWeekday = calendar.component(.weekday, from: feb2026)
+        let offset = (firstWeekday - calendar.firstWeekday + 7) % 7
+        XCTAssertEqual(offset, 0)
+        // Since offset = 0, the first slot should be non-nil (day 1)
+        XCTAssertNotNil(slots[0])
+    }
+
+    func testGridDates_february2024_leapYear_29days() {
+        let calendar = Calendar.current
+        let feb2024 = firstOfMonth(year: 2024, month: 2, calendar: calendar)
+        let slots = CalendarViewLogic.gridDates(for: feb2024, calendar: calendar)
+        let nonNilSlots = slots.compactMap { $0 }
+        XCTAssertEqual(nonNilSlots.count, 29)
+    }
+
+    func testGridDates_december_31days() {
+        let calendar = Calendar.current
+        let dec2025 = firstOfMonth(year: 2025, month: 12, calendar: calendar)
+        let slots = CalendarViewLogic.gridDates(for: dec2025, calendar: calendar)
+        let nonNilSlots = slots.compactMap { $0 }
+        XCTAssertEqual(nonNilSlots.count, 31)
+    }
+
+    // MARK: - nextMonth
+
+    func testNextMonth_advancesOneMonth() {
+        let calendar = Calendar.current
+        let june = firstOfMonth(year: 2025, month: 6)
+        let next = CalendarViewLogic.nextMonth(june, calendar: calendar)
+        let comps = calendar.dateComponents([.year, .month], from: next)
+        XCTAssertEqual(comps.year, 2025)
+        XCTAssertEqual(comps.month, 7)
+    }
+
+    func testNextMonth_decemberWrapsToJanuary() {
+        let calendar = Calendar.current
+        let dec2025 = firstOfMonth(year: 2025, month: 12)
+        let next = CalendarViewLogic.nextMonth(dec2025, calendar: calendar)
+        let comps = calendar.dateComponents([.year, .month], from: next)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 1)
+    }
+
+    // MARK: - previousMonth
+
+    func testPreviousMonth_goesBackOneMonth() {
+        let calendar = Calendar.current
+        let march = firstOfMonth(year: 2026, month: 3)
+        let prev = CalendarViewLogic.previousMonth(march, calendar: calendar)
+        let comps = calendar.dateComponents([.year, .month], from: prev)
+        XCTAssertEqual(comps.year, 2026)
+        XCTAssertEqual(comps.month, 2)
+    }
+
+    func testPreviousMonth_januaryWrapsToDecember() {
+        let calendar = Calendar.current
+        let jan2026 = firstOfMonth(year: 2026, month: 1)
+        let prev = CalendarViewLogic.previousMonth(jan2026, calendar: calendar)
+        let comps = calendar.dateComponents([.year, .month], from: prev)
+        XCTAssertEqual(comps.year, 2025)
+        XCTAssertEqual(comps.month, 12)
+    }
+
+    // MARK: - birthdayPeople
+
+    func testBirthdayPeople_findsCorrectPerson() {
+        let p = makePerson(month: 3, day: 8)
+        let result = CalendarViewLogic.birthdayPeople(inMonth: 3, onDay: 8, from: [p])
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.id, p.id)
+    }
+
+    func testBirthdayPeople_emptyForWrongDay() {
+        let p = makePerson(month: 3, day: 8)
+        let result = CalendarViewLogic.birthdayPeople(inMonth: 3, onDay: 9, from: [p])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBirthdayPeople_excludesIsExcludedPeople() {
+        let excluded = makePerson(month: 5, day: 15, isExcluded: true)
+        let result = CalendarViewLogic.birthdayPeople(inMonth: 5, onDay: 15, from: [excluded])
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testBirthdayPeople_ignoresPeopleWithNoBirthday() {
+        let p = makePerson() // nil month and day
+        let result = CalendarViewLogic.birthdayPeople(inMonth: 1, onDay: 1, from: [p])
+        XCTAssertTrue(result.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the single-screen layout with a `TabView` (Home / Calendar / Settings)
- Adds `CalendarView`: monthly grid with chevron navigation, orange dot indicators on days with birthdays, and a tappable day that shows a person list below using the existing `PersonTileView` + `PersonDetailView`
- Adds `CalendarViewLogic` enum with pure, testable helpers: `gridDates`, `nextMonth`, `previousMonth`, `birthdayPeople`
- Moves Settings from a toolbar sheet to a dedicated tab; removes the "Done" dismiss button
- Removes the gear icon from `BirthdayListView`'s toolbar

## Test plan
- [x] Build succeeds (`xcodebuild build … iPhone 17`)
- [x] All existing PersonTests and WishlistItemTests pass
- [x] 14 new `CalendarViewTests` covering `gridDates` (42-slot count, leading nils, all days present, Feb 2026 28 days, Feb 2024 leap 29 days, Dec 31 days), `nextMonth`/`previousMonth` (advance, wrap), and `birthdayPeople` (finds correct, empty for wrong day, excludes excluded, ignores nil birthday)
- [ ] Manual: launch in simulator — bottom tab bar with 3 tabs; Calendar shows current month; tapping a day with an orange dot shows people below; Settings tab shows full settings without a Done button

🤖 Generated with [Claude Code](https://claude.com/claude-code)