### PR TITLE
Add AI-generated congratulation messages (Anthropic & OpenAI)

### DIFF
--- a/BirthdayReminder/Services/AnthropicService.swift
+++ b/BirthdayReminder/Services/AnthropicService.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+// MARK: - Errors
+
+enum AnthropicError: Error, LocalizedError {
+    case invalidAPIKey
+    case apiError(String)
+    case parsingError
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAPIKey:
+            return "Invalid API key. Please check your Anthropic API key in Settings."
+        case .apiError(let message):
+            return "API error: \(message)"
+        case .parsingError:
+            return "Failed to parse the response from the API."
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - URLSession Protocol (for testability)
+
+protocol URLSessionProtocol {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: URLSessionProtocol {}
+
+// MARK: - AnthropicService
+
+struct AnthropicService {
+    private let session: URLSessionProtocol
+
+    init(session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+
+    // MARK: - Static Helpers
+
+    static func buildPrompt(for person: Person, customPrompt: String?) -> String {
+        let name = person.fullName.isEmpty ? person.givenName : person.fullName
+        var message = "Write a warm 2-3 sentence birthday congratulation for \(name)"
+
+        if let turningAge = person.turningAge {
+            message += ", who is turning \(turningAge) today"
+        }
+
+        message += "."
+
+        if let custom = customPrompt, !custom.isEmpty {
+            message += " \(custom)"
+        }
+
+        return message
+    }
+
+    static func parseResponse(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw AnthropicError.parsingError
+        }
+
+        // Check for API-level error response
+        if let errorObj = json["error"] as? [String: Any],
+           let message = errorObj["message"] as? String {
+            throw AnthropicError.apiError(message)
+        }
+
+        guard let content = json["content"] as? [[String: Any]],
+              !content.isEmpty,
+              let text = content[0]["text"] as? String else {
+            throw AnthropicError.parsingError
+        }
+
+        return text
+    }
+
+    // MARK: - Key Validation
+
+    func validateAPIKey(_ key: String) async throws {
+        guard let url = URL(string: "https://api.anthropic.com/v1/messages") else {
+            throw AnthropicError.apiError("Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(key, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let body: [String: Any] = [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 1,
+            "messages": [["role": "user", "content": "Hi"]]
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let response: URLResponse
+        do {
+            (_, response) = try await session.data(for: request)
+        } catch {
+            throw AnthropicError.networkError(error)
+        }
+
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw AnthropicError.invalidAPIKey
+        }
+    }
+
+    // MARK: - API Call
+
+    func generateCongratulation(for person: Person, apiKey: String, customPrompt: String?) async throws -> String {
+        guard let url = URL(string: "https://api.anthropic.com/v1/messages") else {
+            throw AnthropicError.apiError("Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue("2023-06-01", forHTTPHeaderField: "anthropic-version")
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+
+        let body: [String: Any] = [
+            "model": "claude-haiku-4-5-20251001",
+            "max_tokens": 256,
+            "system": "You are a warm, friendly birthday message writer. Write short, genuine, and personal messages.",
+            "messages": [
+                ["role": "user", "content": Self.buildPrompt(for: person, customPrompt: customPrompt)]
+            ]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let data: Data
+        let response: URLResponse
+
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw AnthropicError.networkError(error)
+        }
+
+        if let http = response as? HTTPURLResponse {
+            switch http.statusCode {
+            case 200...299:
+                break
+            case 401:
+                throw AnthropicError.invalidAPIKey
+            default:
+                let message = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])
+                    .flatMap { $0["error"] as? [String: Any] }
+                    .flatMap { $0["message"] as? String }
+                    ?? "HTTP \(http.statusCode)"
+                throw AnthropicError.apiError(message)
+            }
+        }
+
+        return try Self.parseResponse(data)
+    }
+}

--- a/BirthdayReminder/Services/OpenAIService.swift
+++ b/BirthdayReminder/Services/OpenAIService.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+// MARK: - Errors
+
+enum OpenAIError: Error, LocalizedError {
+    case invalidAPIKey
+    case apiError(String)
+    case parsingError
+    case networkError(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidAPIKey:
+            return "Invalid API key. Please check your OpenAI API key in Settings."
+        case .apiError(let message):
+            return "API error: \(message)"
+        case .parsingError:
+            return "Failed to parse the response from the API."
+        case .networkError(let error):
+            return "Network error: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - OpenAIService
+
+struct OpenAIService {
+    private let session: URLSessionProtocol
+
+    init(session: URLSessionProtocol = URLSession.shared) {
+        self.session = session
+    }
+
+    // MARK: - Static Helpers
+
+    static func buildPrompt(for person: Person, customPrompt: String?) -> String {
+        let name = person.fullName.isEmpty ? person.givenName : person.fullName
+        var message = "Write a warm 2-3 sentence birthday congratulation for \(name)"
+
+        if let turningAge = person.turningAge {
+            message += ", who is turning \(turningAge) today"
+        }
+
+        message += "."
+
+        if let custom = customPrompt, !custom.isEmpty {
+            message += " \(custom)"
+        }
+
+        return message
+    }
+
+    static func parseResponse(_ data: Data) throws -> String {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw OpenAIError.parsingError
+        }
+
+        // Check for API-level error response
+        if let errorObj = json["error"] as? [String: Any],
+           let message = errorObj["message"] as? String {
+            throw OpenAIError.apiError(message)
+        }
+
+        guard let choices = json["choices"] as? [[String: Any]],
+              !choices.isEmpty,
+              let message = choices[0]["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw OpenAIError.parsingError
+        }
+
+        return content
+    }
+
+    // MARK: - Key Validation
+
+    func validateAPIKey(_ key: String) async throws {
+        guard let url = URL(string: "https://api.openai.com/v1/models") else {
+            throw OpenAIError.apiError("Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
+
+        let response: URLResponse
+        do {
+            let result = try await session.data(for: request)
+            response = result.1
+        } catch {
+            throw OpenAIError.networkError(error)
+        }
+
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw OpenAIError.invalidAPIKey
+        }
+    }
+
+    // MARK: - API Call
+
+    func generateCongratulation(for person: Person, apiKey: String, customPrompt: String?) async throws -> String {
+        guard let url = URL(string: "https://api.openai.com/v1/chat/completions") else {
+            throw OpenAIError.apiError("Invalid URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "model": "gpt-4o-mini",
+            "max_tokens": 256,
+            "messages": [
+                [
+                    "role": "system",
+                    "content": "You are a warm, friendly birthday message writer. Write short, genuine, and personal messages."
+                ],
+                [
+                    "role": "user",
+                    "content": Self.buildPrompt(for: person, customPrompt: customPrompt)
+                ]
+            ]
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let data: Data
+        let response: URLResponse
+
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw OpenAIError.networkError(error)
+        }
+
+        if let http = response as? HTTPURLResponse {
+            switch http.statusCode {
+            case 200...299:
+                break
+            case 401:
+                throw OpenAIError.invalidAPIKey
+            default:
+                let message = (try? JSONSerialization.jsonObject(with: data) as? [String: Any])
+                    .flatMap { $0["error"] as? [String: Any] }
+                    .flatMap { $0["message"] as? String }
+                    ?? "HTTP \(http.statusCode)"
+                throw OpenAIError.apiError(message)
+            }
+        }
+
+        return try Self.parseResponse(data)
+    }
+}

--- a/BirthdayReminder/Views/SettingsView.swift
+++ b/BirthdayReminder/Views/SettingsView.swift
@@ -3,10 +3,38 @@ import SwiftData
 
 private enum Keys {
     static let autoRefreshContacts = "autoRefreshContacts"
+    static let anthropicAPIKey = "anthropicAPIKey"
+    static let anthropicCustomPrompt = "anthropicCustomPrompt"
+    static let openAIAPIKey = "openAIAPIKey"
+    static let aiProvider = "aiProvider"
+    static let aiEnabled = "aiEnabled"
+}
+
+private enum KeyStatus: Equatable {
+    case idle
+    case validating
+    case valid
+    case invalid(String)
 }
 
 struct SettingsView: View {
     @AppStorage(Keys.autoRefreshContacts) private var autoRefreshContacts = true
+    @AppStorage(Keys.anthropicAPIKey) private var anthropicAPIKey = ""
+    @AppStorage(Keys.anthropicCustomPrompt) private var anthropicCustomPrompt = ""
+    @AppStorage(Keys.openAIAPIKey) private var openAIAPIKey = ""
+    @AppStorage(Keys.aiProvider) private var aiProvider = "anthropic"
+    @AppStorage(Keys.aiEnabled) private var aiEnabled = false
+
+    @State private var anthropicKeyStatus: KeyStatus = .idle
+    @State private var openAIKeyStatus: KeyStatus = .idle
+
+    private var currentKeyStatus: KeyStatus {
+        aiProvider == "openai" ? openAIKeyStatus : anthropicKeyStatus
+    }
+
+    private var currentKey: String {
+        aiProvider == "openai" ? openAIAPIKey : anthropicAPIKey
+    }
 
     @Environment(\.modelContext) private var modelContext
 
@@ -66,6 +94,43 @@ struct SettingsView: View {
                     Text("Excluded contacts are hidden from your birthday list and won't receive reminders. Swipe left to restore.")
                 }
 
+                // MARK: AI Congratulations
+                Section {
+                    Toggle(isOn: $aiEnabled) {
+                        Label("Enable AI Congratulations", systemImage: "sparkles")
+                    }
+
+                    if aiEnabled {
+                        Picker("Provider", selection: $aiProvider) {
+                            Text("Anthropic").tag("anthropic")
+                            Text("OpenAI").tag("openai")
+                        }
+
+                        if aiProvider == "anthropic" {
+                            SecureField("Paste your Anthropic API key...", text: $anthropicAPIKey)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .onSubmit { validateCurrentKey() }
+                                .onChange(of: anthropicAPIKey) { anthropicKeyStatus = .idle }
+                        } else {
+                            SecureField("Paste your OpenAI API key...", text: $openAIAPIKey)
+                                .textInputAutocapitalization(.never)
+                                .autocorrectionDisabled()
+                                .onSubmit { validateCurrentKey() }
+                                .onChange(of: openAIAPIKey) { openAIKeyStatus = .idle }
+                        }
+
+                        keyStatusRow
+
+                        TextField("Custom prompt (optional)", text: $anthropicCustomPrompt, axis: .vertical)
+                            .lineLimit(3)
+                    }
+                } header: {
+                    Text("AI Congratulations")
+                } footer: {
+                    Text("Your key is stored locally on device only. Get yours at anthropic.com or platform.openai.com.")
+                }
+
                 // MARK: About
                 Section("About") {
                     LabeledContent("Version") {
@@ -81,6 +146,100 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.large)
         }
+    }
+
+    // MARK: - Key Status UI
+
+    @ViewBuilder
+    private var keyStatusRow: some View {
+        if !currentKey.isEmpty || currentKeyStatus != .idle {
+            HStack(spacing: 8) {
+                switch currentKeyStatus {
+                case .idle:
+                    Image(systemName: "key.slash")
+                        .foregroundStyle(.secondary)
+                    Text("Not validated")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .validating:
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text("Validating…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                case .valid:
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundStyle(.green)
+                    Text("Key is valid")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                case .invalid(let msg):
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.red)
+                    Text(msg)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .lineLimit(2)
+                }
+                Spacer()
+                if currentKeyStatus != .validating {
+                    Button("Validate") { validateCurrentKey() }
+                        .font(.caption)
+                        .disabled(currentKey.isEmpty)
+                }
+            }
+        }
+    }
+
+    // MARK: - Validation
+
+    private func validateCurrentKey() {
+        guard !currentKey.isEmpty else { return }
+        let provider = aiProvider
+        let key = currentKey
+        setKeyStatus(.validating, for: provider)
+        Task {
+            do {
+                if provider == "openai" {
+                    try await OpenAIService().validateAPIKey(key)
+                } else {
+                    try await AnthropicService().validateAPIKey(key)
+                }
+                if aiProvider == provider { setKeyStatus(.valid, for: provider) }
+            } catch {
+                if aiProvider == provider {
+                    setKeyStatus(.invalid(shortValidationError(error)), for: provider)
+                }
+            }
+        }
+    }
+
+    private func setKeyStatus(_ status: KeyStatus, for provider: String) {
+        if provider == "openai" {
+            openAIKeyStatus = status
+        } else {
+            anthropicKeyStatus = status
+        }
+    }
+
+    private func shortValidationError(_ error: Error) -> String {
+        if let e = error as? AnthropicError {
+            switch e {
+            case .invalidAPIKey: return "Invalid API key"
+            case .networkError: return "Network error — check your connection"
+            case .apiError(let msg): return msg
+            case .parsingError: return "Unexpected response"
+            }
+        }
+        if let e = error as? OpenAIError {
+            switch e {
+            case .invalidAPIKey: return "Invalid API key"
+            case .networkError: return "Network error — check your connection"
+            case .apiError(let msg): return msg
+            case .parsingError: return "Unexpected response"
+            }
+        }
+        return error.localizedDescription
     }
 
     // MARK: - Helpers

--- a/BirthdayReminderTests/AnthropicServiceTests.swift
+++ b/BirthdayReminderTests/AnthropicServiceTests.swift
@@ -1,0 +1,406 @@
+import XCTest
+import SwiftData
+@testable import BirthdayReminder
+
+// MARK: - MockURLSession
+
+final class MockURLSession: URLSessionProtocol {
+    var stubbedData: Data = Data()
+    var stubbedResponse: URLResponse = HTTPURLResponse(
+        url: URL(string: "https://api.anthropic.com/v1/messages")!,
+        statusCode: 200,
+        httpVersion: nil,
+        headerFields: nil
+    )!
+    var stubbedError: Error? = nil
+    var capturedRequest: URLRequest? = nil
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        capturedRequest = request
+        if let error = stubbedError { throw error }
+        return (stubbedData, stubbedResponse)
+    }
+
+    func setHTTPStatus(_ statusCode: Int) {
+        stubbedResponse = HTTPURLResponse(
+            url: URL(string: "https://api.anthropic.com/v1/messages")!,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+    }
+
+    func setJSONResponse(_ dict: [String: Any]) {
+        stubbedData = (try? JSONSerialization.data(withJSONObject: dict)) ?? Data()
+    }
+}
+
+// MARK: - Helpers
+
+extension AnthropicServiceTests {
+    private func makePerson(given: String = "Jane", family: String = "Doe", year: Int? = nil) -> Person {
+        let p = Person()
+        p.givenName = given
+        p.familyName = family
+        p.birthdayMonth = 6
+        p.birthdayDay = 15
+        p.birthdayYear = year
+        context.insert(p)
+        return p
+    }
+
+    private func successResponse(text: String) -> [String: Any] {
+        [
+            "content": [
+                ["type": "text", "text": text]
+            ],
+            "model": "claude-haiku-4-5-20251001",
+            "role": "assistant"
+        ]
+    }
+}
+
+// MARK: - AnthropicServiceTests
+
+final class AnthropicServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let schema = Schema([Person.self, WishlistItem.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - buildPrompt Tests
+
+    func testBuildPrompt_givenAndFamilyName() {
+        let person = makePerson(given: "Jane", family: "Doe")
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.contains("Jane Doe"), "Prompt should contain full name")
+    }
+
+    func testBuildPrompt_givenNameOnly() {
+        let person = makePerson(given: "Alice", family: "")
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.contains("Alice"), "Prompt should contain given name")
+    }
+
+    func testBuildPrompt_withAge() {
+        // Year such that turningAge is computable — use current year minus some age
+        let currentYear = Calendar.current.component(.year, from: Date())
+        let person = makePerson(given: "Bob", family: "Smith", year: currentYear - 30)
+        // Force birthday to be today or upcoming so turningAge is defined
+        person.birthdayMonth = Calendar.current.component(.month, from: Date())
+        person.birthdayDay = Calendar.current.component(.day, from: Date())
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.contains("turning"), "Prompt should contain 'turning' when age is known")
+        XCTAssertTrue(prompt.contains("30"), "Prompt should contain the age")
+    }
+
+    func testBuildPrompt_withoutAge_noYear() {
+        let person = makePerson(given: "Carol", family: "White", year: nil)
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertFalse(prompt.contains("turning"), "Prompt should not mention age when year is unknown")
+    }
+
+    func testBuildPrompt_withCustomPrompt() {
+        let person = makePerson(given: "Dan", family: "Brown")
+        let custom = "Keep it funny and short."
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: custom)
+        XCTAssertTrue(prompt.contains(custom), "Custom prompt should be appended")
+    }
+
+    func testBuildPrompt_withoutCustomPrompt() {
+        let person = makePerson(given: "Eve", family: "Black")
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.hasSuffix("."), "Prompt without custom text should end with period")
+    }
+
+    func testBuildPrompt_withEmptyCustomPrompt_notAppended() {
+        let person = makePerson(given: "Frank", family: "Green")
+        let prompt = AnthropicService.buildPrompt(for: person, customPrompt: "")
+        XCTAssertTrue(prompt.hasSuffix("."), "Empty custom prompt should not be appended")
+    }
+
+    // MARK: - parseResponse Tests
+
+    func testParseResponse_validResponse_extractsText() throws {
+        let json = successResponse(text: "Happy Birthday!")
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = try AnthropicService.parseResponse(data)
+        XCTAssertEqual(result, "Happy Birthday!")
+    }
+
+    func testParseResponse_missingContentKey_throwsParsingError() throws {
+        let json: [String: Any] = ["role": "assistant"]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try AnthropicService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? AnthropicError, AnthropicError.parsingError)
+        }
+    }
+
+    func testParseResponse_emptyContentArray_throwsParsingError() throws {
+        let json: [String: Any] = ["content": [[String: Any]]()]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try AnthropicService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? AnthropicError, AnthropicError.parsingError)
+        }
+    }
+
+    func testParseResponse_malformedJSON_throwsParsingError() {
+        let data = Data("not json at all".utf8)
+        XCTAssertThrowsError(try AnthropicService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? AnthropicError, AnthropicError.parsingError)
+        }
+    }
+
+    func testParseResponse_apiErrorResponse_throwsAPIError() throws {
+        let json: [String: Any] = [
+            "error": ["type": "invalid_request_error", "message": "Bad request"]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try AnthropicService.parseResponse(data)) { error in
+            if case .apiError(let msg) = error as? AnthropicError {
+                XCTAssertEqual(msg, "Bad request")
+            } else {
+                XCTFail("Expected apiError but got \(error)")
+            }
+        }
+    }
+
+    // MARK: - generateCongratulation Tests
+
+    func testGenerateCongratulation_success_returnsText() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Wishing you a wonderful birthday!"))
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson(given: "Gina", family: "Hill")
+        let result = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+        XCTAssertEqual(result, "Wishing you a wonderful birthday!")
+    }
+
+    func testGenerateCongratulation_http401_throwsInvalidAPIKey() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(401)
+        mockSession.setJSONResponse(["error": ["message": "Unauthorized"]])
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "bad-key", customPrompt: nil)
+            XCTFail("Expected invalidAPIKey error")
+        } catch {
+            XCTAssertEqual(error as? AnthropicError, AnthropicError.invalidAPIKey)
+        }
+    }
+
+    func testGenerateCongratulation_http500_throwsAPIError() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(500)
+        mockSession.setJSONResponse(["error": ["message": "Internal server error"]])
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+            XCTFail("Expected apiError")
+        } catch {
+            if case .apiError(let msg) = error as? AnthropicError {
+                XCTAssertEqual(msg, "Internal server error")
+            } else {
+                XCTFail("Expected apiError but got \(error)")
+            }
+        }
+    }
+
+    func testGenerateCongratulation_networkFailure_throwsNetworkError() async {
+        let mockSession = MockURLSession()
+        mockSession.stubbedError = URLError(.notConnectedToInternet)
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+            XCTFail("Expected networkError")
+        } catch {
+            if case .networkError = error as? AnthropicError {
+                // expected
+            } else {
+                XCTFail("Expected networkError but got \(error)")
+            }
+        }
+    }
+
+    func testGenerateCongratulation_requestHeaders() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson()
+        _ = try await service.generateCongratulation(for: person, apiKey: "sk-test-12345", customPrompt: nil)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "x-api-key"), "sk-test-12345")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "content-type"), "application/json")
+    }
+
+    func testGenerateCongratulation_requestBody_containsModelAndMaxTokens() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson()
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+
+        XCTAssertEqual(body["model"] as? String, "claude-haiku-4-5-20251001")
+        XCTAssertEqual(body["max_tokens"] as? Int, 256)
+    }
+
+    func testGenerateCongratulation_withCustomPrompt_appendedInBody() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson(given: "Hank", family: "Ford")
+        let customPrompt = "Make it rhyme."
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: customPrompt)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages.first?["content"] as? String)
+
+        XCTAssertTrue(userContent.contains("Make it rhyme."), "Custom prompt should appear in message body")
+    }
+
+    func testGenerateCongratulation_withEmptyCustomPrompt_notAppended() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = AnthropicService(session: mockSession)
+        let person = makePerson(given: "Iris", family: "Lang")
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: "")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages.first?["content"] as? String)
+
+        // With nil passed for empty string, there should be no extra content after the final period
+        XCTAssertTrue(userContent.hasSuffix("."), "No extra text should be appended for empty custom prompt")
+    }
+
+    // MARK: - validateAPIKey Tests
+
+    func testValidateAPIKey_success_doesNotThrow() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(["id": "msg_123"])
+
+        let service = AnthropicService(session: mockSession)
+        try await service.validateAPIKey("valid-key")  // should not throw
+    }
+
+    func testValidateAPIKey_http401_throwsInvalidAPIKey() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(401)
+
+        let service = AnthropicService(session: mockSession)
+        do {
+            try await service.validateAPIKey("bad-key")
+            XCTFail("Expected invalidAPIKey error")
+        } catch {
+            XCTAssertEqual(error as? AnthropicError, AnthropicError.invalidAPIKey)
+        }
+    }
+
+    func testValidateAPIKey_http500_doesNotThrow() async throws {
+        // Only 401 maps to invalidAPIKey; other errors are not validation failures
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(500)
+        mockSession.setJSONResponse([:])
+
+        let service = AnthropicService(session: mockSession)
+        try await service.validateAPIKey("test-key")  // should not throw
+    }
+
+    func testValidateAPIKey_networkError_throwsNetworkError() async {
+        let mockSession = MockURLSession()
+        mockSession.stubbedError = URLError(.notConnectedToInternet)
+
+        let service = AnthropicService(session: mockSession)
+        do {
+            try await service.validateAPIKey("test-key")
+            XCTFail("Expected networkError")
+        } catch {
+            if case .networkError = error as? AnthropicError {
+                // expected
+            } else {
+                XCTFail("Expected networkError but got \(error)")
+            }
+        }
+    }
+
+    func testValidateAPIKey_requestHeaders_correct() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse([:])
+
+        let service = AnthropicService(session: mockSession)
+        try await service.validateAPIKey("sk-ant-test-key")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "x-api-key"), "sk-ant-test-key")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "anthropic-version"), "2023-06-01")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "content-type"), "application/json")
+    }
+
+    func testValidateAPIKey_requestMethod_isPost() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse([:])
+
+        let service = AnthropicService(session: mockSession)
+        try await service.validateAPIKey("test-key")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.httpMethod, "POST")
+    }
+}
+
+// MARK: - AnthropicError Equatable
+
+extension AnthropicError: Equatable {
+    public static func == (lhs: AnthropicError, rhs: AnthropicError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidAPIKey, .invalidAPIKey): return true
+        case (.parsingError, .parsingError): return true
+        case (.apiError(let a), .apiError(let b)): return a == b
+        case (.networkError, .networkError): return true
+        default: return false
+        }
+    }
+}

--- a/BirthdayReminderTests/ContactsServiceTests.swift
+++ b/BirthdayReminderTests/ContactsServiceTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+import Contacts
+import SwiftData
+@testable import BirthdayReminder
+
+// MARK: - MockContactStore
+
+final class MockContactStore: @unchecked Sendable, ContactStoreProtocol {
+    var stubbedGranted = true
+    var stubbedAccessError: Error? = nil
+    var stubbedContacts: [CNContact] = []
+    var stubbedEnumerateError: Error? = nil
+
+    func requestAccess(for entityType: CNEntityType, completionHandler: @escaping @Sendable (Bool, Error?) -> Void) {
+        if let error = stubbedAccessError {
+            completionHandler(false, error)
+        } else {
+            completionHandler(stubbedGranted, nil)
+        }
+    }
+
+    func enumerateContacts(with fetchRequest: CNContactFetchRequest, usingBlock block: @escaping (CNContact, UnsafeMutablePointer<ObjCBool>) -> Void) throws {
+        if let error = stubbedEnumerateError { throw error }
+        for contact in stubbedContacts {
+            var stop: ObjCBool = false
+            withUnsafeMutablePointer(to: &stop) { ptr in
+                block(contact, ptr)
+            }
+        }
+    }
+}
+
+// MARK: - ContactsServiceTests
+
+final class ContactsServiceTests: XCTestCase {
+
+    private var mockStore: MockContactStore!
+    private var service: ContactsService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        mockStore = MockContactStore()
+        service = ContactsService(store: mockStore)
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        mockStore = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private func makeContact(withBirthday: Bool, given: String = "Test") -> CNMutableContact {
+        let c = CNMutableContact()
+        c.givenName = given
+        if withBirthday {
+            var comps = DateComponents()
+            comps.month = 6
+            comps.day = 15
+            c.birthday = comps
+        }
+        return c
+    }
+
+    // MARK: - requestPermission
+
+    func testRequestPermission_granted_returnsTrue() async throws {
+        mockStore.stubbedGranted = true
+        let result = try await service.requestPermission()
+        XCTAssertTrue(result)
+    }
+
+    func testRequestPermission_denied_returnsFalse() async throws {
+        mockStore.stubbedGranted = false
+        let result = try await service.requestPermission()
+        XCTAssertFalse(result)
+    }
+
+    func testRequestPermission_storeError_throws() async {
+        let expectedError = NSError(domain: "CNErrorDomain", code: 100)
+        mockStore.stubbedAccessError = expectedError
+        do {
+            _ = try await service.requestPermission()
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "CNErrorDomain")
+            XCTAssertEqual(error.code, 100)
+        }
+    }
+
+    // MARK: - fetchBirthdayContacts
+
+    func testFetchBirthdayContacts_returnsContactsWithBirthday() async throws {
+        mockStore.stubbedContacts = [
+            makeContact(withBirthday: true, given: "Alice"),
+            makeContact(withBirthday: true, given: "Bob"),
+        ]
+        let result = try await service.fetchBirthdayContacts()
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testFetchBirthdayContacts_filtersOutContactsWithoutBirthday() async throws {
+        mockStore.stubbedContacts = [
+            makeContact(withBirthday: true, given: "Alice"),
+            makeContact(withBirthday: false, given: "NoBirthday"),
+        ]
+        let result = try await service.fetchBirthdayContacts()
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result[0].givenName, "Alice")
+    }
+
+    func testFetchBirthdayContacts_emptyStore_returnsEmpty() async throws {
+        mockStore.stubbedContacts = []
+        let result = try await service.fetchBirthdayContacts()
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testFetchBirthdayContacts_allContactsWithoutBirthday_returnsEmpty() async throws {
+        mockStore.stubbedContacts = [
+            makeContact(withBirthday: false, given: "A"),
+            makeContact(withBirthday: false, given: "B"),
+        ]
+        let result = try await service.fetchBirthdayContacts()
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    func testFetchBirthdayContacts_storeError_throws() async {
+        mockStore.stubbedEnumerateError = NSError(domain: "CNErrorDomain", code: 200)
+        do {
+            _ = try await service.fetchBirthdayContacts()
+            XCTFail("Expected error to be thrown")
+        } catch let error as NSError {
+            XCTAssertEqual(error.domain, "CNErrorDomain")
+            XCTAssertEqual(error.code, 200)
+        }
+    }
+}

--- a/BirthdayReminderTests/NotificationServiceTests.swift
+++ b/BirthdayReminderTests/NotificationServiceTests.swift
@@ -1,0 +1,278 @@
+import XCTest
+import SwiftData
+import UserNotifications
+@testable import BirthdayReminder
+
+// MARK: - MockNotificationCenter
+
+final class MockNotificationCenter: NotificationCenterProtocol {
+    var stubbedIsAuthorized = false
+    var stubbedAuthorizationResult = true
+    var stubbedAuthorizationError: Error? = nil
+    var stubbedAddError: Error? = nil
+
+    private(set) var removeAllPendingCalled = false
+    private(set) var addedRequests: [UNNotificationRequest] = []
+    private(set) var removedPendingIdentifiers: [String] = []
+    private(set) var removedDeliveredIdentifiers: [String] = []
+
+    func isAlreadyAuthorized() async -> Bool { stubbedIsAuthorized }
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
+        if let error = stubbedAuthorizationError { throw error }
+        return stubbedAuthorizationResult
+    }
+
+    func removeAllPendingNotificationRequests() {
+        removeAllPendingCalled = true
+    }
+
+    func add(_ request: UNNotificationRequest) async throws {
+        if let error = stubbedAddError { throw error }
+        addedRequests.append(request)
+    }
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+        removedPendingIdentifiers.append(contentsOf: identifiers)
+    }
+
+    func removeDeliveredNotifications(withIdentifiers identifiers: [String]) {
+        removedDeliveredIdentifiers.append(contentsOf: identifiers)
+    }
+}
+
+// MARK: - NotificationServiceTests
+
+final class NotificationServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+    private var mockCenter: MockNotificationCenter!
+    private var service: NotificationService!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let schema = Schema([Person.self, WishlistItem.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = ModelContext(container)
+        mockCenter = MockNotificationCenter()
+        service = NotificationService(center: mockCenter)
+    }
+
+    override func tearDownWithError() throws {
+        service = nil
+        mockCenter = nil
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - Helpers
+
+    private func makePerson(
+        given: String = "Alice",
+        family: String = "Smith",
+        month: Int = 6,
+        day: Int = 15,
+        year: Int? = nil,
+        congratulatedYear: Int? = nil
+    ) -> Person {
+        let p = Person()
+        p.givenName = given
+        p.familyName = family
+        p.birthdayMonth = month
+        p.birthdayDay = day
+        p.birthdayYear = year
+        p.congratulatedYear = congratulatedYear
+        context.insert(p)
+        return p
+    }
+
+    private var todayMonth: Int { Calendar.current.component(.month, from: Date()) }
+    private var todayDay: Int { Calendar.current.component(.day, from: Date()) }
+    private var currentYear: Int { Calendar.current.component(.year, from: Date()) }
+
+    // MARK: - requestPermission
+
+    func testRequestPermission_alreadyAuthorized_returnsTrueWithoutRequesting() async {
+        mockCenter.stubbedIsAuthorized = true
+        let result = await service.requestPermission()
+        XCTAssertTrue(result)
+    }
+
+    func testRequestPermission_notAuthorized_requestGranted_returnsTrue() async {
+        mockCenter.stubbedIsAuthorized = false
+        mockCenter.stubbedAuthorizationResult = true
+        let result = await service.requestPermission()
+        XCTAssertTrue(result)
+    }
+
+    func testRequestPermission_notAuthorized_requestDenied_returnsFalse() async {
+        mockCenter.stubbedIsAuthorized = false
+        mockCenter.stubbedAuthorizationResult = false
+        let result = await service.requestPermission()
+        XCTAssertFalse(result)
+    }
+
+    func testRequestPermission_notAuthorized_requestThrows_returnsFalse() async {
+        mockCenter.stubbedIsAuthorized = false
+        mockCenter.stubbedAuthorizationError = URLError(.unknown)
+        let result = await service.requestPermission()
+        XCTAssertFalse(result)
+    }
+
+    // MARK: - rescheduleAll
+
+    func testRescheduleAll_alwaysCallsRemoveAllPending() async {
+        await service.rescheduleAll(people: [])
+        XCTAssertTrue(mockCenter.removeAllPendingCalled)
+    }
+
+    func testRescheduleAll_emptyList_noNotificationsAdded() async {
+        await service.rescheduleAll(people: [])
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty)
+    }
+
+    func testRescheduleAll_futureBirthday_usesCalendarTrigger() async {
+        // Use a month that is not today
+        let month = (todayMonth % 12) + 1
+        let person = makePerson(month: month, day: 15)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        let trigger = mockCenter.addedRequests[0].trigger
+        XCTAssertTrue(trigger is UNCalendarNotificationTrigger, "Future birthday should use calendar trigger")
+        let calTrigger = trigger as? UNCalendarNotificationTrigger
+        XCTAssertEqual(calTrigger?.dateComponents.month, month)
+        XCTAssertEqual(calTrigger?.dateComponents.day, 15)
+        XCTAssertTrue(calTrigger?.repeats ?? false)
+    }
+
+    func testRescheduleAll_birthdayToday_usesTimeIntervalTrigger() async {
+        let person = makePerson(month: todayMonth, day: todayDay)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        let trigger = mockCenter.addedRequests[0].trigger
+        XCTAssertTrue(trigger is UNTimeIntervalNotificationTrigger, "Today's birthday should use time interval trigger")
+        let timeTrigger = trigger as? UNTimeIntervalNotificationTrigger
+        XCTAssertEqual(timeTrigger?.timeInterval, 2)
+        XCTAssertFalse(timeTrigger?.repeats ?? true)
+    }
+
+    func testRescheduleAll_congratulatedPerson_isFiltered() async {
+        let person = makePerson(congratulatedYear: currentYear)
+        await service.rescheduleAll(people: [person])
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty)
+    }
+
+    func testRescheduleAll_personWithNoBirthdayMonth_isFiltered() async {
+        let p = Person()
+        p.givenName = "No"
+        p.familyName = "Birthday"
+        p.birthdayMonth = nil
+        p.birthdayDay = nil
+        context.insert(p)
+        await service.rescheduleAll(people: [p])
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty)
+    }
+
+    func testRescheduleAll_personWithMonthButNilDay_isSkipped() async {
+        // Passes the filter (birthdayMonth != nil) but fails the guard (birthdayDay is nil)
+        let p = Person()
+        p.givenName = "Bad"
+        p.familyName = "Data"
+        p.birthdayMonth = 5
+        p.birthdayDay = nil
+        context.insert(p)
+        await service.rescheduleAll(people: [p])
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty)
+    }
+
+    func testRescheduleAll_notificationIdFormat() async {
+        let person = makePerson(month: (todayMonth % 12) + 1, day: 10)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        XCTAssertEqual(mockCenter.addedRequests[0].identifier, "birthday-\(person.id.uuidString)")
+    }
+
+    func testRescheduleAll_notificationContent_includesPersonName() async {
+        let person = makePerson(given: "Jane", family: "Doe", month: (todayMonth % 12) + 1, day: 10)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        XCTAssertTrue(mockCenter.addedRequests[0].content.title.contains("Jane Doe"))
+    }
+
+    func testRescheduleAll_notificationContent_withKnownAge_showsTurningAge() async {
+        let person = makePerson(
+            month: todayMonth,
+            day: todayDay,
+            year: currentYear - 30
+        )
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        XCTAssertTrue(mockCenter.addedRequests[0].content.body.contains("Turning 30"))
+    }
+
+    func testRescheduleAll_notificationContent_withoutAge_showsFallback() async {
+        // No birth year → turningAge is nil → fallback body
+        let person = makePerson(month: (todayMonth % 12) + 1, day: 10, year: nil)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        XCTAssertEqual(mockCenter.addedRequests[0].content.body, "Don't forget to reach out!")
+    }
+
+    func testRescheduleAll_notificationContent_personIdInUserInfo() async {
+        let person = makePerson(month: (todayMonth % 12) + 1, day: 10)
+        await service.rescheduleAll(people: [person])
+        XCTAssertEqual(mockCenter.addedRequests.count, 1)
+        let userInfo = mockCenter.addedRequests[0].content.userInfo
+        XCTAssertEqual(userInfo["personID"] as? String, person.id.uuidString)
+    }
+
+    func testRescheduleAll_limitsTo64Notifications() async {
+        // Create 65 people with different future birthdays
+        var people: [Person] = []
+        for i in 1...65 {
+            let month = ((i - 1) % 11) + 1  // months 1-11, avoiding today
+            let day = (i % 28) + 1
+            // Skip month+day combos that match today
+            let effectiveMonth = (month == todayMonth && day == todayDay) ? (month % 11) + 1 : month
+            people.append(makePerson(given: "Person\(i)", month: effectiveMonth, day: day))
+        }
+        await service.rescheduleAll(people: people)
+        XCTAssertLessThanOrEqual(mockCenter.addedRequests.count, 64)
+    }
+
+    func testRescheduleAll_addError_isSilentlyIgnored() async {
+        mockCenter.stubbedAddError = URLError(.unknown)
+        let person = makePerson(month: (todayMonth % 12) + 1, day: 10)
+        // Should not throw — uses try? internally
+        await service.rescheduleAll(people: [person])
+        // No crash = success; add was attempted (error swallowed)
+        XCTAssertTrue(mockCenter.addedRequests.isEmpty)
+    }
+
+    // MARK: - cancelNotification
+
+    func testCancelNotification_removesPendingWithCorrectId() {
+        let id = UUID()
+        service.cancelNotification(for: id)
+        XCTAssertEqual(mockCenter.removedPendingIdentifiers, ["birthday-\(id.uuidString)"])
+    }
+
+    func testCancelNotification_removesDeliveredWithCorrectId() {
+        let id = UUID()
+        service.cancelNotification(for: id)
+        XCTAssertEqual(mockCenter.removedDeliveredIdentifiers, ["birthday-\(id.uuidString)"])
+    }
+
+    func testCancelNotification_differentIds_areIndependent() {
+        let id1 = UUID()
+        let id2 = UUID()
+        service.cancelNotification(for: id1)
+        service.cancelNotification(for: id2)
+        XCTAssertEqual(mockCenter.removedPendingIdentifiers.count, 2)
+        XCTAssertEqual(mockCenter.removedPendingIdentifiers[0], "birthday-\(id1.uuidString)")
+        XCTAssertEqual(mockCenter.removedPendingIdentifiers[1], "birthday-\(id2.uuidString)")
+    }
+}

--- a/BirthdayReminderTests/OpenAIServiceTests.swift
+++ b/BirthdayReminderTests/OpenAIServiceTests.swift
@@ -1,0 +1,348 @@
+import XCTest
+import SwiftData
+@testable import BirthdayReminder
+
+// MARK: - Helpers
+
+extension OpenAIServiceTests {
+    private func makePerson(given: String = "Jane", family: String = "Doe", year: Int? = nil) -> Person {
+        let p = Person()
+        p.givenName = given
+        p.familyName = family
+        p.birthdayMonth = 6
+        p.birthdayDay = 15
+        p.birthdayYear = year
+        context.insert(p)
+        return p
+    }
+
+    private func successResponse(text: String) -> [String: Any] {
+        [
+            "choices": [
+                [
+                    "message": [
+                        "role": "assistant",
+                        "content": text
+                    ]
+                ]
+            ]
+        ]
+    }
+}
+
+// MARK: - OpenAIServiceTests
+
+final class OpenAIServiceTests: XCTestCase {
+
+    private var container: ModelContainer!
+    private var context: ModelContext!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let schema = Schema([Person.self, WishlistItem.self])
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        container = try ModelContainer(for: schema, configurations: [config])
+        context = ModelContext(container)
+    }
+
+    override func tearDownWithError() throws {
+        context = nil
+        container = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - buildPrompt Tests
+
+    func testBuildPrompt_givenAndFamilyName() {
+        let person = makePerson(given: "Jane", family: "Doe")
+        let prompt = OpenAIService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.contains("Jane Doe"), "Prompt should contain full name")
+    }
+
+    func testBuildPrompt_givenNameOnly() {
+        let person = makePerson(given: "Alice", family: "")
+        let prompt = OpenAIService.buildPrompt(for: person, customPrompt: nil)
+        XCTAssertTrue(prompt.contains("Alice"), "Prompt should contain given name")
+    }
+
+    func testBuildPrompt_withCustomPrompt() {
+        let person = makePerson(given: "Dan", family: "Brown")
+        let custom = "Keep it funny and short."
+        let prompt = OpenAIService.buildPrompt(for: person, customPrompt: custom)
+        XCTAssertTrue(prompt.contains(custom), "Custom prompt should be appended")
+    }
+
+    func testBuildPrompt_withEmptyCustomPrompt_notAppended() {
+        let person = makePerson(given: "Frank", family: "Green")
+        let prompt = OpenAIService.buildPrompt(for: person, customPrompt: "")
+        XCTAssertTrue(prompt.hasSuffix("."), "Empty custom prompt should not be appended")
+    }
+
+    // MARK: - parseResponse Tests
+
+    func testParseResponse_validResponse_extractsText() throws {
+        let json = successResponse(text: "Happy Birthday!")
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let result = try OpenAIService.parseResponse(data)
+        XCTAssertEqual(result, "Happy Birthday!")
+    }
+
+    func testParseResponse_missingChoicesKey_throwsParsingError() throws {
+        let json: [String: Any] = ["id": "chatcmpl-123"]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try OpenAIService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? OpenAIError, OpenAIError.parsingError)
+        }
+    }
+
+    func testParseResponse_emptyChoicesArray_throwsParsingError() throws {
+        let json: [String: Any] = ["choices": [[String: Any]]()]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try OpenAIService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? OpenAIError, OpenAIError.parsingError)
+        }
+    }
+
+    func testParseResponse_malformedJSON_throwsParsingError() {
+        let data = Data("not json at all".utf8)
+        XCTAssertThrowsError(try OpenAIService.parseResponse(data)) { error in
+            XCTAssertEqual(error as? OpenAIError, OpenAIError.parsingError)
+        }
+    }
+
+    func testParseResponse_apiErrorResponse_throwsAPIError() throws {
+        let json: [String: Any] = [
+            "error": ["type": "invalid_request_error", "message": "Bad request"]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        XCTAssertThrowsError(try OpenAIService.parseResponse(data)) { error in
+            if case .apiError(let msg) = error as? OpenAIError {
+                XCTAssertEqual(msg, "Bad request")
+            } else {
+                XCTFail("Expected apiError but got \(error)")
+            }
+        }
+    }
+
+    // MARK: - generateCongratulation Tests
+
+    func testGenerateCongratulation_success_returnsText() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Wishing you a wonderful birthday!"))
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson(given: "Gina", family: "Hill")
+        let result = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+        XCTAssertEqual(result, "Wishing you a wonderful birthday!")
+    }
+
+    func testGenerateCongratulation_http401_throwsInvalidAPIKey() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(401)
+        mockSession.setJSONResponse(["error": ["message": "Unauthorized"]])
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "bad-key", customPrompt: nil)
+            XCTFail("Expected invalidAPIKey error")
+        } catch {
+            XCTAssertEqual(error as? OpenAIError, OpenAIError.invalidAPIKey)
+        }
+    }
+
+    func testGenerateCongratulation_http500_throwsAPIError() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(500)
+        mockSession.setJSONResponse(["error": ["message": "Internal server error"]])
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+            XCTFail("Expected apiError")
+        } catch {
+            if case .apiError(let msg) = error as? OpenAIError {
+                XCTAssertEqual(msg, "Internal server error")
+            } else {
+                XCTFail("Expected apiError but got \(error)")
+            }
+        }
+    }
+
+    func testGenerateCongratulation_networkFailure_throwsNetworkError() async {
+        let mockSession = MockURLSession()
+        mockSession.stubbedError = URLError(.notConnectedToInternet)
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson()
+        do {
+            _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+            XCTFail("Expected networkError")
+        } catch {
+            if case .networkError = error as? OpenAIError {
+                // expected
+            } else {
+                XCTFail("Expected networkError but got \(error)")
+            }
+        }
+    }
+
+    func testGenerateCongratulation_requestHeaders() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson()
+        _ = try await service.generateCongratulation(for: person, apiKey: "sk-test-12345", customPrompt: nil)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer sk-test-12345")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
+    func testGenerateCongratulation_requestBody_containsModelAndMaxTokens() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson()
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: nil)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+
+        XCTAssertEqual(body["model"] as? String, "gpt-4o-mini")
+        XCTAssertEqual(body["max_tokens"] as? Int, 256)
+    }
+
+    func testGenerateCongratulation_withCustomPrompt_appendedInBody() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson(given: "Hank", family: "Ford")
+        let customPrompt = "Make it rhyme."
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: customPrompt)
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages.last?["content"] as? String)
+
+        XCTAssertTrue(userContent.contains("Make it rhyme."), "Custom prompt should appear in message body")
+    }
+
+    func testGenerateCongratulation_withEmptyCustomPrompt_notAppended() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(successResponse(text: "Happy Birthday!"))
+
+        let service = OpenAIService(session: mockSession)
+        let person = makePerson(given: "Iris", family: "Lang")
+        _ = try await service.generateCongratulation(for: person, apiKey: "test-key", customPrompt: "")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        let bodyData = try XCTUnwrap(req.httpBody)
+        let body = try XCTUnwrap(JSONSerialization.jsonObject(with: bodyData) as? [String: Any])
+        let messages = try XCTUnwrap(body["messages"] as? [[String: Any]])
+        let userContent = try XCTUnwrap(messages.last?["content"] as? String)
+
+        XCTAssertTrue(userContent.hasSuffix("."), "No extra text should be appended for empty custom prompt")
+    }
+
+    // MARK: - validateAPIKey Tests
+
+    func testValidateAPIKey_success_doesNotThrow() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse(["object": "list"])
+
+        let service = OpenAIService(session: mockSession)
+        try await service.validateAPIKey("valid-key")  // should not throw
+    }
+
+    func testValidateAPIKey_http401_throwsInvalidAPIKey() async {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(401)
+
+        let service = OpenAIService(session: mockSession)
+        do {
+            try await service.validateAPIKey("bad-key")
+            XCTFail("Expected invalidAPIKey error")
+        } catch {
+            XCTAssertEqual(error as? OpenAIError, OpenAIError.invalidAPIKey)
+        }
+    }
+
+    func testValidateAPIKey_http500_doesNotThrow() async throws {
+        // Only 401 maps to invalidAPIKey; other status codes are not validation failures
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(500)
+        mockSession.setJSONResponse([:])
+
+        let service = OpenAIService(session: mockSession)
+        try await service.validateAPIKey("test-key")  // should not throw
+    }
+
+    func testValidateAPIKey_networkError_throwsNetworkError() async {
+        let mockSession = MockURLSession()
+        mockSession.stubbedError = URLError(.notConnectedToInternet)
+
+        let service = OpenAIService(session: mockSession)
+        do {
+            try await service.validateAPIKey("test-key")
+            XCTFail("Expected networkError")
+        } catch {
+            if case .networkError = error as? OpenAIError {
+                // expected
+            } else {
+                XCTFail("Expected networkError but got \(error)")
+            }
+        }
+    }
+
+    func testValidateAPIKey_requestHeaders_correct() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse([:])
+
+        let service = OpenAIService(session: mockSession)
+        try await service.validateAPIKey("sk-openai-test-key")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Authorization"), "Bearer sk-openai-test-key")
+    }
+
+    func testValidateAPIKey_requestMethod_isGet() async throws {
+        let mockSession = MockURLSession()
+        mockSession.setHTTPStatus(200)
+        mockSession.setJSONResponse([:])
+
+        let service = OpenAIService(session: mockSession)
+        try await service.validateAPIKey("test-key")
+
+        let req = try XCTUnwrap(mockSession.capturedRequest)
+        XCTAssertEqual(req.httpMethod, "GET")
+    }
+}
+
+// MARK: - OpenAIError Equatable
+
+extension OpenAIError: Equatable {
+    public static func == (lhs: OpenAIError, rhs: OpenAIError) -> Bool {
+        switch (lhs, rhs) {
+        case (.invalidAPIKey, .invalidAPIKey): return true
+        case (.parsingError, .parsingError): return true
+        case (.apiError(let a), .apiError(let b)): return a == b
+        case (.networkError, .networkError): return true
+        default: return false
+        }
+    }
+}

--- a/BirthdayReminderTests/SharedContainerTests.swift
+++ b/BirthdayReminderTests/SharedContainerTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+import SwiftData
+@testable import BirthdayReminder
+
+final class SharedContainerTests: XCTestCase {
+
+    // MARK: - makeSharedModelContainer
+
+    func testMakeSharedModelContainer_noGroupURL_returnsFallbackContainer() {
+        // When no App Group URL is available (always the case in tests),
+        // the function must fall back to the default container and not crash.
+        let container = makeSharedModelContainer(groupURL: nil)
+        XCTAssertNotNil(container)
+    }
+
+    func testMakeSharedModelContainer_validGroupURL_usesGroupURL() throws {
+        // Provide a writable temp URL so the App Group path succeeds.
+        let tempURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".store")
+        defer { try? FileManager.default.removeItem(atPath: tempURL.path) }
+
+        let container = makeSharedModelContainer(groupURL: tempURL)
+        XCTAssertNotNil(container)
+    }
+
+    func testMakeSharedModelContainer_unreachableGroupURL_fallsBackToDefault() {
+        // A path inside a non-existent directory forces ModelContainer creation
+        // to fail, exercising the fallback branch.
+        let badURL = URL(fileURLWithPath: "/nonexistent/deep/path/\(UUID().uuidString).store")
+        let container = makeSharedModelContainer(groupURL: badURL)
+        XCTAssertNotNil(container)
+    }
+}

--- a/BirthdayReminderTests/WidgetDataManagerTests.swift
+++ b/BirthdayReminderTests/WidgetDataManagerTests.swift
@@ -163,4 +163,14 @@ final class WidgetDataManagerTests: XCTestCase {
         XCTAssertEqual(loaded[0].name, "New1")
         XCTAssertEqual(loaded[1].name, "New2")
     }
+
+    func testWidgetDataManager_corruptData_returnsEmpty() {
+        guard let defaults = UserDefaults(suiteName: WidgetDataManager.suiteName) else { return }
+        defer { defaults.removeObject(forKey: WidgetDataManager.key) }
+
+        // Write bytes that are valid Data but not a valid [WidgetBirthday] JSON
+        defaults.set(Data("not-valid-json-at-all".utf8), forKey: WidgetDataManager.key)
+        let result = WidgetDataManager.load()
+        XCTAssertTrue(result.isEmpty, "Corrupt data in UserDefaults should return empty array")
+    }
 }

--- a/Shared/SharedContainer.swift
+++ b/Shared/SharedContainer.swift
@@ -1,13 +1,14 @@
 import Foundation
 import SwiftData
 
-func makeSharedModelContainer() -> ModelContainer {
+func makeSharedModelContainer(
+    groupURL: URL? = FileManager.default
+        .containerURL(forSecurityApplicationGroupIdentifier: "group.kkulykk.BirthdayReminder")?
+        .appending(path: "BirthdayReminder.store")
+) -> ModelContainer {
     let schema = Schema([Person.self, WishlistItem.self])
-    let groupID = "group.kkulykk.BirthdayReminder"
 
-    if let groupURL = FileManager.default
-        .containerURL(forSecurityApplicationGroupIdentifier: groupID)?
-        .appending(path: "BirthdayReminder.store") {
+    if let groupURL {
         let config = ModelConfiguration(schema: schema, url: groupURL)
         if let container = try? ModelContainer(for: schema, configurations: [config]) {
             return container


### PR DESCRIPTION
## Summary

- Adds `AnthropicService` and `OpenAIService` to generate birthday congratulation messages using claude-haiku-4-5 and gpt-4o-mini respectively
- Updates `PersonDetailView` with an AI generation button/sheet (shown only when AI is enabled and a key is set)
- Updates `SettingsView` with provider picker, secure API key fields, real-time validation, and custom prompt input
- Extracts `ContactStoreProtocol` and `NotificationCenterProtocol` for testability; makes `makeSharedModelContainer` injectable
- Adds full test coverage: `AnthropicServiceTests`, `OpenAIServiceTests`, `ContactsServiceTests`, `NotificationServiceTests`, `SharedContainerTests`, extended `WidgetDataManagerTests`

## Test plan

- [ ] Run Tests pipeline via GitHub Actions → Tests → Run workflow
- [ ] Verify AI button appears in PersonDetailView when `aiEnabled = true` and a key is set
- [ ] Verify key validation shows correct status (valid/invalid/network error)
- [ ] Verify all new unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)